### PR TITLE
Convert bytes objects into str in Python3 with encoding argument

### DIFF
--- a/pyrestful/types.py
+++ b/pyrestful/types.py
@@ -30,6 +30,8 @@ def convert(value, type):
 	if issubclass(type,str) and not (value.upper() in ['FALSE','TRUE']):
 		return value.decode('utf-8')
 	elif issubclass(type,unicode):
+		if isinstance(value, bytes):
+			return unicode(value, encoding="utf-8")
 		return unicode(value)
 	elif issubclass(type,int):
 		return int(value)


### PR DESCRIPTION
In Python3
[https://docs.python.org/3/library/stdtypes.html#str](url)
> Passing a bytes object to str() without the encoding or errors arguments falls under the first case of returning the informal string representation (see also the -b command-line option to Python). For example:

`str(b'Zoot!')`  return  "b'Zoot!'" rather than "Zoot!"
so when 'value' is byteslike , add the 'encoding' for str()
